### PR TITLE
Reorder atoms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Python byte-compiled files
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# qc2gam
-A python program to convert orbital and basis set information into GAMESS style format -- Although it is envisioned to eventually convert any QC orbs -> any QC orbs
+qc2gam
+======
+A Python program to convert orbital and basis set information into GAMESS style
+format -- Although it is envisioned to eventually convert any QC orbs -> any QC
+orbs

--- a/columbus.py
+++ b/columbus.py
@@ -181,7 +181,7 @@ def read_mos(mocoef_file, in_cart, basis):
     # move to the first line of the orbital coefficients, reading nao and nmo
     # along the way
     line_index = 0
-    while(mo_file[line_index].split()[0][0] != '('):
+    while mo_file[line_index].split()[0][0] != '(':
         line_index += 1
         # figure out nao, nmo
         if mo_file[line_index].split()[0].lower() == 'a':

--- a/columbus.py
+++ b/columbus.py
@@ -6,23 +6,26 @@ import sys
 import numpy as np
 import moinfo
 
+
 # DALTON orbital ordering (in cartesians)
-# s px py pz dxx dxy dxz dyy dyz dzz fxxx fxxy fxxz fxyy fxyz fxzz fyyy fyyz fyzz fzzz
-ao_ordr         = [['s'],
-                   ['px','py','pz'],
-                   ['dxx','dxy','dxz','dyy','dyz','dzz'],
-                   ['fxxx','fxxy','fxxz','fxyy','fxyz',
-                    'fxzz','fyyy','fyyz','fyzz','fzzz']]
+# s px py pz dxx dxy dxz dyy dyz dzz
+# fxxx fxxy fxxz fxyy fxyz fxzz fyyy fyyz fyzz fzzz
+ao_ordr = [['s'],
+           ['px', 'py', 'pz'],
+           ['dxx', 'dxy', 'dxz', 'dyy', 'dyz', 'dzz'],
+           ['fxxx', 'fxxy', 'fxxz', 'fxyy', 'fxyz',
+            'fxzz', 'fyyy', 'fyyz', 'fyzz', 'fzzz']]
 
-ao_norm         = [[1.],
-                   [1.,1.,1.],
-                   [np.sqrt(3.),np.sqrt(3.),np.sqrt(3.),np.sqrt(3.),
-                    np.sqrt(3.),np.sqrt(3.)],
-                   [np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),
-                    np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),
-                    np.sqrt(15.),np.sqrt(15.)]]
+ao_norm = [[1.],
+           [1.,1.,1.],
+           [np.sqrt(3.),np.sqrt(3.),np.sqrt(3.),np.sqrt(3.),
+            np.sqrt(3.),np.sqrt(3.)],
+           [np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),
+            np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),
+            np.sqrt(15.),np.sqrt(15.)]]
 
-# how to convert from spherical to cartesian basis functions (in columubs ordering)
+# how to convert from spherical to cartesian basis functions
+# (in columbus ordering)
 # s -> s | px -> px | py -> py | pz -> pz
 # d ordering: d2-, d1-, d0, d1+ ,d2+
 # dxx ->  -d0 + d2+
@@ -42,30 +45,30 @@ ao_norm         = [[1.],
 # fyyz -> f0 - f2
 # fyzz -> 4 * f1-
 # fzzz -> -2 * f0 / 3
-sph2cart        = [
-                   [ [[0],[1.]] ],                                     # conversion for s orbitals
-                   [ [[0],[1.]], [[1],[1.]], [[2],[1.]] ],             # conversion for p orbitals
-                   [ [[2,4],[-1.,1]],
-                     [[0],[1.]],
-                     [[3],[1.]],          # conversion for d orbitals
-                     [[2,4],[-1.,-1.]],
-                     [[1],[1.]],
-                     [[2],[2.]] ],
-                   [ [[4,6],[-1.,-1./15.]],
-                     [[0,2],[np.sqrt(2.),-1.]], # conversion for f orbitals
-                     [[3,5],[1.,1.]],
-                     [[4,6],[-1.,1.]],
-                     [[1],[1.]],
-                     [[4],[4.]],
-                     [[0,2],[-np.sqrt(2.),-1.]],
-                     [[3,5],[1.,-1.]],
-                     [[2],[4.]],
-                     [[3], [-2./3.]] ]
-                  ]
+sph2cart = [
+    [[[0], [1.]]],                           # conversion for s orbitals
+    [[[0], [1.]], [[1], [1.]], [[2], [1.]]], # conversion for p orbitals
+    [[[2, 4], [-1., 1]],                     # conversion for d orbitals
+     [[0], [1.]],
+     [[3], [1.]],
+     [[2, 4], [-1., -1.]],
+     [[1], [1.]],
+     [[2], [2.]]],
+    [[[4, 6], [-1., -1./15.]],               # conversion for f orbitals
+     [[0, 2], [np.sqrt(2.), -1.]],
+     [[3, 5], [1., 1.]],
+     [[4, 6], [-1., 1.]],
+     [[1], [1.]],
+     [[4], [4.]],
+     [[0, 2], [-np.sqrt(2.), -1.]],
+     [[3, 5], [1., -1.]],
+     [[2], [4.]],
+     [[3], [-2./3.]]]
+            ]
 
 
 def parse(geom_file, geom_ordr, basis_file, mo_file):
-    """Documentation to come"""
+    """Parses a set of columbus input files."""
     # read columbus geometry file
     gam_geom = read_geom(geom_file)
     if geom_ordr is not None:
@@ -82,7 +85,7 @@ def parse(geom_file, geom_ordr, basis_file, mo_file):
 
 
 def read_geom(geom_file):
-    """Reads a columbus geom and loads results into moinfo.Geom format"""
+    """Reads a columbus geom and loads results into moinfo.Geom."""
     # create geometry object to hold the data
     geom = moinfo.Geom()
 
@@ -102,9 +105,9 @@ def read_geom(geom_file):
 
 
 def read_basis(basis_file, geom):
-    """Documentation to come"""
+    """Reads a columbus basis file into moinfo.BasisSet."""
     # create basis set object
-    basis = moinfo.BasisSet('unknown',geom)
+    basis = moinfo.BasisSet('unknown', geom)
 
     # slurp up daltaoin file
     with open(basis_file, 'r') as daltaoin:
@@ -135,7 +138,8 @@ def read_basis(basis_file, geom):
           i+=1
           a_sym, a_index, x, y, z, sym = bfile[i].split()
           if a_sym.upper().rjust(2) != geom.atoms[atm_cnt+k].symbol:
-              raise ValueError('Mismatch between daltaoin and geom file, atom='+str(atm_cnt+k))
+              raise ValueError('Mismatch between daltaoin and geom file, ' +
+                               'atom='+str(atm_cnt+k))
 
         # loop over the number of angular momentum shells
         ang_mom = -1
@@ -163,13 +167,13 @@ def read_basis(basis_file, geom):
 
 
 def read_mos(mocoef_file, in_cart, basis):
-    """Documentation to come"""
+    """Reads the columbus molecular orbital file into moinfo.Orbitals.
 
-    # So: in the future, we should also allow for a mapping array that
-    # allows for taking linear combinations of elements in order to convert
-    # from a spherically adapted basis to cartesians. That will come later
-    # though...first the easy stuff.
-
+    So: in the future, we should also allow for a mapping array that
+    allows for taking linear combinations of elements in order to convert
+    from a spherically adapted basis to cartesians. That will come later
+    though... first the easy stuff.
+    """
     # slurp up the mocoef file
     with open(mocoef_file, 'r') as mocoef:
         mo_file = mocoef.readlines()
@@ -180,11 +184,11 @@ def read_mos(mocoef_file, in_cart, basis):
     while(mo_file[line_index].split()[0][0] != '('):
         line_index += 1
         # figure out nao, nmo
-        if mo_file[line_index].split()[0] == 'A':
-            nao, nmo = list(map(int,mo_file[line_index-1].split()))
+        if mo_file[line_index].split()[0].lower() == 'a':
+            nao, nmo = list(map(int, mo_file[line_index-1].split()))
 
     # create a numpy array to hold orbitals
-    col_orb = np.zeros((nao,nmo),dtype=float)
+    col_orb = np.zeros((nao, nmo), dtype=float)
     for i in range(nmo):
         n_remain = nao
         row      = 0
@@ -192,9 +196,22 @@ def read_mos(mocoef_file, in_cart, basis):
             line_index += 1
             line_arr    = mo_file[line_index].split()
             col_orb[3*row:3*row+min(n_remain,3),i] = np.array(
-               [line_arr[k].replace('D','e') for k in range(len(line_arr))],dtype=float)
-            n_remain -= min(n_remain,3)
+               [line_arr[k].replace('D','e') for k in range(len(line_arr))],
+               dtype=float)
+            n_remain -= min(n_remain, 3)
             row += 1
+
+    # create a numpy array to hold populations, if present
+    col_occ = np.zeros(nmo, dtype=float)
+    nocc = 0
+    for i in range(2, len(mo_file)):
+        if 'orbocc' in mo_file[i-2] or nocc > 0:
+            occ_line = np.array(mo_file[i].replace('D','e').split(), dtype=float)
+            nrow = len(occ_line)
+            col_occ[nocc:nocc+nrow] = occ_line
+            nocc += nrow
+    if nocc == 0:
+        col_occ = None
 
     # if in spherically adapted orbitals, first convert
     # to cartesians
@@ -208,6 +225,7 @@ def read_mos(mocoef_file, in_cart, basis):
     # copy orbitals into gam_orb
     gam_orb = moinfo.Orbitals(nao_cart, nmo)
     gam_orb.mo_vectors = col_orb_cart
+    gam_orb.occ = col_occ
 
     # construct mapping array from COLUMBUS to GAMESS
     dalt_gam_map, scale_col, scale_gam = basis.construct_map(ao_ordr, ao_norm)
@@ -225,11 +243,11 @@ def read_mos(mocoef_file, in_cart, basis):
 
 
 def generate_csf_list(ci_file):
-    """Generates a list of CSFs from a cipcls file"""
+    """Generates a list of CSFs from a cipcls file."""
     valid, is_cipc = is_cipcls(ci_file)
 
     if not valid:
-        raise SyntaxError('Cannot parse csf list output: not cipcls or mcpcls\n')
+        raise SyntaxError('Cannot parse csf list output: not cipcls or mcpcls')
 
     # parse cipcls or mcpcls file
     n_occ, n_extl, csf_list = parse_ci_file(ci_file, is_cipc)
@@ -241,7 +259,7 @@ def generate_csf_list(ci_file):
 def is_cipcls(in_file):
     """Returns true, true if the file to parse is a cipcls file,
     true, false if mcpcls file, and false, false is file not
-    recognized"""
+    recognized."""
     ci_str = 'PROGRAM:              CIPC'
     mc_str = 'PROGRAM:              MCPC'
 
@@ -260,7 +278,7 @@ def is_cipcls(in_file):
 
 
 def parse_ci_file(ci_file, is_cipc):
-    """Parses cipcls file, extract csf list and coefficients"""
+    """Parses cipcls file, extracts csf list and coefficients."""
     csf_list   = []
     ci_str     = '  ------- -------- ------- - ---- --- ---- --- ------------'
     mc_str     = '-----  ------------  ------------  ------------'
@@ -325,8 +343,7 @@ def parse_ci_file(ci_file, is_cipc):
 
 
 def print_csf_list(n_occ, n_extl, csf_list):
-    """Prints csf list in csf2det format"""
-
+    """Prints csf list in csf2det format."""
     csf_fmt = ('{:14.10f}'+''.join('{:2d}' for i in range(n_occ))+
                            ''.join('{:4d}:{:2d}' for i in range(n_extl))+
                            '\n')
@@ -352,7 +369,7 @@ def print_csf_list(n_occ, n_extl, csf_list):
 
 
 def parse_ci_line(is_cipc, ndocc, l_arr):
-    """Parses an occupation array from cipcls or mcpcls"""
+    """Parses an occupation array from cipcls or mcpcls."""
     csf_vec = [3] * ndocc
 
     if is_cipc:

--- a/columbus.py
+++ b/columbus.py
@@ -190,28 +190,27 @@ def read_mos(mocoef_file, in_cart, basis):
     # create a numpy array to hold orbitals
     col_orb = np.zeros((nao, nmo), dtype=float)
     for i in range(nmo):
-        n_remain = nao
-        row      = 0
-        while(n_remain > 0):
+        norb = 0
+        while norb < nao:
             line_index += 1
-            line_arr    = mo_file[line_index].split()
-            col_orb[3*row:3*row+min(n_remain,3),i] = np.array(
-               [line_arr[k].replace('D','e') for k in range(len(line_arr))],
-               dtype=float)
-            n_remain -= min(n_remain, 3)
-            row += 1
+            line_arr = mo_file[line_index].replace('D','e').split()
+            nrow = len(line_arr)
+            col_orb[norb:norb+nrow,i] = np.array(line_arr, dtype=float)
+            norb += nrow
 
     # create a numpy array to hold populations, if present
     col_occ = np.zeros(nmo, dtype=float)
     nocc = 0
-    for i in range(2, len(mo_file)):
-        if 'orbocc' in mo_file[i-2] or nocc > 0:
-            occ_line = np.array(mo_file[i].replace('D','e').split(), dtype=float)
-            nrow = len(occ_line)
-            col_occ[nocc:nocc+nrow] = occ_line
+    while nocc < nmo:
+        line_index += 1
+        if line_index > len(mo_file):
+            col_occ = None
+            break
+        elif 'orbocc' in mo_file[line_index-2] or nocc > 0:
+            line_arr = mo_file[line_index].replace('D','e').split()
+            nrow = len(line_arr)
+            col_occ[nocc:nocc+nrow] = np.array(line_arr, dtype=float)
             nocc += nrow
-    if nocc == 0:
-        col_occ = None
 
     # if in spherically adapted orbitals, first convert
     # to cartesians

--- a/dalton.py
+++ b/dalton.py
@@ -1,16 +1,9 @@
-# 
-# A set of routines to parse the output of a dalton
-# calculation
-#
-#
-
+"""
+A set of routines to parse the output of a dalton
+calculation
+"""
 import os
 
 
 def parse():
-
-    return
-
-
-
-#
+    pass

--- a/moinfo.py
+++ b/moinfo.py
@@ -206,10 +206,10 @@ class Orbitals:
         n_col = 5
         n_row = int(np.ceil(n_orb / n_col))
         with open(file_name, 'a') as mo_file:
-            mo_file.write(' $RDMPCE\n')
+            mo_file.write(' $OCCNO\n')
             for i in range(n_row):
                 n_end = min(n_orb, 5*(i+1))
-                oc_row = (n_end - 5*i)*'{:15.12f}' + '\n'
+                oc_row = (n_end - 5*i)*'{:16.10f}' + '\n'
                 r_data = self.occ[5*i:n_end]
                 mo_file.write(oc_row.format(*r_data))
             mo_file.write(' $END\n')

--- a/moinfo.py
+++ b/moinfo.py
@@ -1,8 +1,7 @@
-# 
-# A set of standard structures to store basis set
-# of MO information
-#
-
+"""
+A set of standard structures to store basis set
+of MO information
+"""
 import os
 import math
 import numpy as np
@@ -17,7 +16,7 @@ a_numbers       = [ '1.0', '2.0',
 
 ang_mom_sym     = ['S','P','D','F','G','H','I']
 
-nfunc_cart      = [1, 3, 6, 10] 
+nfunc_cart      = [1, 3, 6, 10]
 
 nfunc_sph       = [1, 3, 5, 7]
 
@@ -36,14 +35,11 @@ ao_norm         = [[1.],
 au2ang          = 0.529177249
 
 
-# converts orbitals from spherical to cartesian
-# AO basis
 def sph2cart(basis, mo_sph, s2c):
     """Converts orbitals from spherical to cartesian AO basis. Assumes
        input orbitals are numpy array"""
-
-    (nao_sph, nmo) = mo_sph.shape
-    [l_cart, l_sph] = basis.ang_mom_lst()
+    nao_sph, nmo = mo_sph.shape
+    l_cart, l_sph = basis.ang_mom_lst()
 
     orb_trans = [[] for i in range(nmo)]
     iao_sph   = 0
@@ -58,17 +54,14 @@ def sph2cart(basis, mo_sph, s2c):
         iao_sph  += nfunc_sph[lval]
 
     if iao_sph != basis.n_bf_sph:
-        sys.exit('Error in sph2cart: '+str(iao_sph)+'!='+str(basis.n_bf_sph))
+        raise ValueError('Error in sph2cart: {:d} != {:d}'.format(iao_sph, basis.n_bf_sph))
 
-    mo_cart      = np.array(orb_trans).T
-    return mo_cart
+    return np.array(orb_trans).T
 
-# wrapper for all requisite data about an atom
-class atom:
-    """Documentation to come"""
 
+class Atom:
+    """Wrapper for all requisite data about an atom."""
     def __init__(self, label, coords=None):
-        """Documentation to come"""
         # atomic symbol
         self.symbol    = label
 
@@ -76,7 +69,7 @@ class atom:
         try:
             self.number = a_numbers[a_symbols.index(self.symbol)]
         except:
-            print('Atom: '+str(label)+' not found,'+ 
+            print('Atom: '+str(label)+' not found,'+
                   'setting atomic number to \'0\'\n')
             self.number = '0.0'
 
@@ -86,50 +79,64 @@ class atom:
         else:
             self.coords = coords
 
-    # define the coordinates of the atom
     def set_coords(self, coords):
-        """Documentation to come"""
+        """Defines the coordinates of the atom."""
         self.coords = coords
 
-    # print the atom in GAMESS file format
     def print_atom(self, file_handle):
-        """Documentation to come"""
+        """Prints the atom in GAMESS file format."""
         ofmt   = ('{:2s}'+'{:>5s}'+
                   ''.join('{:18.10f}' for i in range(3))+'\n')
-        w_data = [self.symbol,self.number] + self.coords
+        w_data = [self.symbol, self.number] + self.coords
         file_handle.write(ofmt.format(*w_data))
-            
 
-# class to hold geometry information
-class geom:
-    """Documentation to come"""
 
+class Geom:
+    """Class to hold geometry information."""
     def __init__(self, atoms=None):
         """Documentation to come"""
         # if atoms is None, initialize empty atom list
         if atoms is None:
-            self.atoms = []
+            self.atoms = np.array([], dtype=object)
         else:
-            self.atoms = atoms
+            self.atoms = np.array(atoms)
+        self.atom_map = np.arange(self.natoms())
 
     def add_atom(self, atom):
         """Documentation to come"""
-        self.atoms.append(atom)
-        return
+        nat = self.natoms()
+        self.atoms = np.hstack((self.atoms, atom))
+        self.atom_map = np.hstack((self.atom_map, nat))
 
     def natoms(self):
         """Documentation to come"""
-        return len(self.atoms)   
+        return len(self.atoms)
+
+    def reorder(self, other_geom):
+        """Reorders a geometry to match another geometry and keeps
+        the mapping to use on mos."""
+        fmt = '{:10.4e}{:10.4e}{:10.4e}'
+        scoords = [fmt.format(*atm.coords) for atm in self.atoms]
+        ocoords = [fmt.format(*atm.coords) for atm in other_geom.atoms]
+        self.atom_map = self._find_map(ocoords, scoords)
+        self.atoms = self.atoms[self.atom_map]
 
     def print_geom(self, file_handle):
         """Prints geometry in GAMESS format"""
         for i in range(self.natoms()):
             self.atoms[i].print_atom(file_handle)
-  
-# wrapper to hold information about the orbitals
-class orbitals:
-    """Documentation to come"""
 
+    def _find_map(self, arr1, arr2):
+        """Finds a map between two arrays."""
+        o1 = np.argsort(arr1)
+        o2 = np.argsort(arr2)
+        q = np.empty_like(o1)
+        q[o1] = np.arange(len(o1))
+        return o2[q]
+
+
+class Orbitals:
+    """Wrapper to hold information about the orbitals."""
     def __init__(self, n_aos, n_mos):
         """Documentation to come"""
         # number of AOs
@@ -139,59 +146,47 @@ class orbitals:
         # matrix holding MOs
         self.mo_vectors = np.zeros((n_aos,n_mos),dtype=float)
 
-    # add an orbital to the end of the list (i.e. at first column with norm==0
     def add(self, mo_vec):
-        """Documentation to come"""
-
+        """Adds an orbital to the end of the list (i.e. at first column
+        with norm==0)"""
         # only add orbital if the number of aos is correct
         if len(mo_vec) != self.naos:
             print("Cannot add orbital, wrong number of naos: "+
                    str(len(mo_vec))+"!="+str(self.naos))
-            return
+            return None
 
         i = 0
         while(np.linalg.norm(self.mo_vectors[:,i]) > 1.e-10):
             i += 1
         self.mo_vectors[:,i] = mo_vec
-        return
 
-   # insert an orbital
     def insert(self, mo_vec, mo_i):
-        """Documentation to come"""
+        """Inserts an orbital."""
         self.mo_vectors = np.insert(self.mo_vectors,mo_i,mo_vec,axis=1)
-        return
 
-    # delete an orbital
     def delete(self, mo_i):
-        """Documentation to come"""
+        """Deletes an orbital."""
         self.mo_vectors = np.delete(self.mo_vectors,mo_i,axis=1)
-        return
 
-    # scale each MO by the vector fac_vec
     def scale(self, fac_vec):
-        """scale each MO by the vector fac_vec"""
+        """Scales each MO by the vector fac_vec"""
         scale_fac       = np.array(fac_vec)
         old_mos         = self.mo_vectors.T
         new_mos         = np.array([mo * scale_fac for mo in old_mos]).T
         self.mo_vectors = new_mos
 
-    # re-sort mos according to a map array
     def sort(self, map_lst):
-        """re-sort the MOs, ordering the AO indices via map_lst"""
+        """Re-sorts the MOs, ordering the AO indices via map_lst"""
         for i in range(self.nmos):
             vec_srt = self.mo_vectors[map_lst,i]
-            self.mo_vectors[:,i] = vec_srt 
-        return
+            self.mo_vectors[:,i] = vec_srt
 
-    # take the norm of an orbital
     def norm(self, mo_i):
-        """Documentation to come"""
+        """Takes the norm of an orbital."""
         np.linalg.norm(self.mo_vectors[:,mo_i])
-        return
 
-    # print orbitals in gamess style VEC format
     def print_orbitals(self, file_name, n_orb=None):
-        """Documentation to come"""
+        """Prints orbitals in gamess style VEC format."""
         # default is to print all the orbitals
         if n_orb is None:
             n_orb = self.nmos
@@ -203,15 +198,12 @@ class orbitals:
                 self.print_movec(mo_file, i)
             mo_file.write(' $END\n')
 
-        return
-
-    # print an orbital vector
     def print_movec(self, file_handle, mo_i):
-        """Documentation to come"""
+        """Prints an orbital vector."""
         n_col  = 5 # this is set by GAMESS format
         n_row  = int(math.ceil(self.naos/n_col))
         mo_lab = (mo_i+1) % 100
- 
+
         def mo_row(n):
             return ('{:>2d}'+' '+'{:>2d}'+''.join('{:15.8E}' for i in range(n))+'\n')
 
@@ -220,16 +212,14 @@ class orbitals:
             n_coef  = min(self.naos,5*(i+1)) - 5*i
             r_data.extend(self.mo_vectors[5*i:min(self.naos,5*(i+1)),mo_i].tolist())
             file_handle.write(mo_row(n_coef).format(*r_data))
-        return
 
-# an object to hold information about a single basis function
-# including angular momentum, exponents and contraction coefficients
-class basis_function:
-    """Documentation to come"""
 
+class BasisFunction:
+    """An object to hold information about a single basis function
+    including angular momentum, exponents and contraction coefficients."""
     def __init__(self, ang_mom):
         # angular momentum of basis function
-        self.ang_mom = ang_mom 
+        self.ang_mom = ang_mom
         # text symbol of the angular momentum shell
         self.ang_sym = ang_mom_sym[self.ang_mom]
         # number of primitives in basis
@@ -244,7 +234,6 @@ class basis_function:
         self.exps.extend([expo])
         self.coefs.extend([coef])
         self.n_prim += 1
-        return
 
     def print_basis_function(self, file_handle):
         """Documentation to come"""
@@ -256,11 +245,10 @@ class basis_function:
         for i in range(self.n_prim):
             w_data = [i+1, self.exps[i],self.coefs[i]]
             file_handle.write(ofmt2.format(*w_data))
-        return
 
-# contains the basis set information for a single atom
-class basis_set:
-    """Documentation to come"""
+
+class BasisSet:
+    """Contains the basis set information for a single atom."""
     def __init__(self, label, geom):
         # string label of basis set name
         self.label       = label
@@ -271,16 +259,13 @@ class basis_set:
         # total number of spherical functions
         self.n_bf_sph    = 0
         # total number of contractions for atom i
-        self.n_bf        = [0 for i in range(self.geom.natoms())]       
+        self.n_bf        = [0 for i in range(self.geom.natoms())]
         # list of basis function objects
         self.basis_funcs = [[] for i in range(self.geom.natoms())]
 
-    # construct an array of the ang_mom of each basis function in 
-    # GAMESS ordering -- returns both cartesian array and spherically
-    # adapted array
     def ang_mom_lst(self):
-        """Returns an array containing the value of angular momentum of the 
-           corresponding at that index"""
+        """Returns an array containing the value of angular momentum of the
+        corresponding at that index"""
         ang_mom_cart = []
         ang_mom_sph  = []
 
@@ -290,11 +275,11 @@ class basis_set:
                 ang_mom_cart.extend([ang_mom for k in range(nfunc_cart[ang_mom])])
                 ang_mom_sph.extend([ang_mom for k in range(nfunc_sph[ang_mom])])
 
-        return[ang_mom_cart, ang_mom_sph]
+        return ang_mom_cart, ang_mom_sph
 
-    # add a basis function to the basis_set -- always keeps "like" angular 
-    # momentum functions together
     def add_function(self, atom_i, bf):
+        """Adds a basis function to the basis_set -- always keeps "like"
+        angular momentum functions together"""
         ang_mom = bf.ang_mom
         if len(self.basis_funcs[atom_i])>0:
             bf_i = 0
@@ -306,28 +291,23 @@ class basis_set:
             bf_i = len(self.basis_funcs[atom_i])
 
         self.basis_funcs[atom_i].insert(bf_i, bf)
-        self.n_bf[atom_i]   += 1
-        self.n_bf_cart      += nfunc_cart[bf.ang_mom]
-        self.n_bf_sph       += nfunc_sph[bf.ang_mom]
-        return
+        self.n_bf[atom_i] += 1
+        self.n_bf_cart    += nfunc_cart[bf.ang_mom]
+        self.n_bf_sph     += nfunc_sph[bf.ang_mom]
 
-    # construct a mapping between the ordering of basis functions
-    # in an arbitrary order and the 'canonical' GAMESS order
-    # mapping also assumes 'canonical' cartesian representation
-    # of AOs
     def construct_map(self, orig_ordr, orig_norm):
-        """constructs a map array to convert the nascent AO ordering to
-           GAMESS AO ordering. Also returns the normalization factors
-           for the nascent and corresponding GAMESS-ordered AO basis"""
+        """Constructs a map array to convert the nascent AO ordering to
+        GAMESS AO ordering. Also returns the normalization factors
+        for the nascent and corresponding GAMESS-ordered AO basis."""
         map_arr       = []
         scale_nascent = []
         scale_gam     = []
-        ao_map        = [[orig_ordr[i].index(ao_ordr[i][j]) 
-                         for j in range(nfunc_cart[i])] 
+        ao_map        = [[orig_ordr[i].index(ao_ordr[i][j])
+                         for j in range(nfunc_cart[i])]
                          for i in range(len(ao_ordr))]
 
         nf_cnt = 0
-        for i in range(self.geom.natoms()):
+        for i in self.geom.atom_map:
             for j in range(len(self.basis_funcs[i])):
                 ang_mom = self.basis_funcs[i][j].ang_mom
                 nfunc   = nfunc_cart[ang_mom]
@@ -337,12 +317,11 @@ class basis_set:
                 scale_gam.extend([1./ao_norm[ang_mom][k] for k in range(nfunc)])
                 nf_cnt += nfunc
 
-        return [map_arr, scale_nascent, scale_gam]
+        return map_arr, scale_nascent, scale_gam
 
-
-    # print  the data section of a GAMESS style input file
     def print_basis_set(self, file_name):
-    
+        """Print the data section of a GAMESS style input file."""
+
         # if file doesn't exist, create it. Overwrite if it does exist
         with open(file_name, 'x') as dat_file:
             dat_file.write(' $DATA\n'+
@@ -352,11 +331,8 @@ class basis_set:
             for i in range(self.geom.natoms()):
                 self.geom.atoms[i].print_atom(dat_file)
                 for j in range(self.n_bf[i]):
-                    self.basis_funcs[i][j].print_basis_function(dat_file)       
+                    self.basis_funcs[i][j].print_basis_function(dat_file)
                 # each atomic record ends with an empty line
                 dat_file.write('\n')
 
             dat_file.write(' $END\n')
-
-        return
-

--- a/qc2gam.py
+++ b/qc2gam.py
@@ -10,61 +10,39 @@ import dalton
 import turbomole
 
 
-def process_arguments(args):
+def get_arg(kwd, default):
+    """Gets a keyword argument from sys.argv if present, otherwise sets
+    the value to a given default."""
+    args = sys.argv
+    if kwd in args:
+        return args[args.index(kwd)+1]
+    else:
+        return default
+
+
+def process_arguments():
     """Process command line arguments."""
-    input_style = None
-    geom_file   = None
-    gorder      = None
-    mo_file     = None
-    basis_file  = None
-    ci_file     = None
-    out_file    = None
-
-    # read the command line arguments
-    if '-input' in sys.argv:
-        input_style = args[args.index('-input')+1]
-
-    if '-geom' in sys.argv:
-        geom_file = args[args.index('-geom')+1]
-
-    if '-ordr' in sys.argv:
-        gorder = args[args.index('-ordr')+1]
-
-    if '-mos' in sys.argv:
-        mo_file  = args[args.index('-mos')+1]
-
-    if '-basis' in sys.argv:
-        basis_file = args[args.index('-basis')+1]
-
-    if '-ci' in sys.argv:
-        ci_file    = args[args.index('-ci')+1]
-
-    if '-output' in sys.argv:
-        out_file   = args[args.index('-output')+1]
-
-    # use the default output file name (mos.dat) if this has not been given
-    # by the user
-    if out_file == None:
-        out_file = 'mos.dat'
-
-    # if they have not been given, fill in the names of the geometry,
+    # if they have not been given, fill in the names of the output, geometry,
     # MO and basis files using the names usually used by the given program
+    input_style = get_arg('-input', None)
     if input_style == 'turbomole':
-        if geom_file == None:
-            geom_file = 'coord'
-        if mo_file == None:
-            mo_file = 'mos'
-        if basis_file == None:
-            basis_file = 'basis'
+        geom_file = 'coord'
+        mo_file = 'mos'
+        basis_file = 'basis'
     elif input_style == 'columbus':
-        if geom_file == None:
-            geom_file = 'geom'
-        if mo_file == None:
-            mo_file = 'mocoef'
-        if basis_file == None:
-            basis_file = 'daltaoin'
+        geom_file = 'geom'
+        mo_file = 'mocoef'
+        basis_file = 'daltaoin'
     else:
         raise ValueError('input style '+str(inp)+' not recognized.')
+
+    # read the command line arguments
+    geom_file  = get_arg('-geom', geom_file)
+    mo_file    = get_arg('-mos', mo_file)
+    basis_file = get_arg('-basis', basis_file)
+    gorder     = get_arg('-ordr', None)
+    ci_file    = get_arg('-ci', None)
+    out_file   = get_arg('-output', 'mos.dat')
 
     return input_style, geom_file, gorder, basis_file, mo_file, ci_file, out_file
 
@@ -72,7 +50,7 @@ def process_arguments(args):
 def convert(inp, gm, go, basis, mos, ci, out):
     """Convert orbital/basis information to GAMESS format."""
     # import the appropriate module
-    qc_input =__import__(inp, fromlist=['a'])
+    qc_input = __import__(inp, fromlist=['a'])
 
     if ci is not None:
         qc_input.generate_csf_list(ci)
@@ -83,12 +61,13 @@ def convert(inp, gm, go, basis, mos, ci, out):
     # print the MOs file
     gam_basis.print_basis_set(out)
     gam_mos.print_orbitals(out)
+    if gam_mos.occ is not None:
+        gam_mos.print_occ(out)
 
 
 if __name__ == '__main__':
     # parse command line arguments
-    args = process_arguments(sys.argv)
+    args = process_arguments()
 
     # run the program
     convert(*args)
-

--- a/turbomole.py
+++ b/turbomole.py
@@ -7,23 +7,25 @@ import numpy as np
 import moinfo
 
 # TURBOMOLE orbital ordering (in cartesians)
-# s px py pz dxx dxy dxz dyy dyz dzz fxxx fxxy fxxz fxyy fxyz fxzz fyyy fyyz fyzz fzzz
-ao_ordr         = [['s'],
-                   ['px','py','pz'],
-                   ['dxx','dyy','dzz','dxy','dxz','dyz'],
-                   ['fxxx','fyyy','fzzz','fxxy','fxxz',
-                    'fxyy','fyyz','fxzz','fyzz','fxyz']]
+# s px py pz dxx dxy dxz dyy dyz dzz
+# fxxx fxxy fxxz fxyy fxyz fxzz fyyy fyyz fyzz fzzz
+ao_ordr = [['s'],
+           ['px', 'py', 'pz'],
+           ['dxx', 'dyy', 'dzz', 'dxy', 'dxz', 'dyz'],
+           ['fxxx', 'fyyy', 'fzzz', 'fxxy', 'fxxz',
+            'fxyy', 'fyyz', 'fxzz', 'fyzz', 'fxyz']]
 
-ao_norm         = [[1.],
-                   [1.,1.,1.],
-                   [np.sqrt(3.),np.sqrt(3.),np.sqrt(3.),
-                    np.sqrt(3.),np.sqrt(3.),np.sqrt(3.)],
-                   [np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),
-                    np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),np.sqrt(15.),
-                    np.sqrt(15.),np.sqrt(15.)]]
+ao_norm = [[1.],
+           [1., 1., 1.],
+           [np.sqrt(3.), np.sqrt(3.), np.sqrt(3.),
+            np.sqrt(3.), np.sqrt(3.), np.sqrt(3.)],
+           [np.sqrt(15.), np.sqrt(15.), np.sqrt(15.), np.sqrt(15.),
+            np.sqrt(15.), np.sqrt(15.), np.sqrt(15.), np.sqrt(15.),
+            np.sqrt(15.), np.sqrt(15.)]]
 
 
-# how to convert from spherical to cartesian basis functions (in turbomole ordering)
+# how to convert from spherical to cartesian basis functions
+# (in turbomole ordering)
 # s -> s | px -> px | py -> py | pz -> pz
 # d ordering: d0, d1, d1-, d2-, d2
 # dxx ->  0.5*( -d0/sqrt(3) + d2+ )
@@ -44,30 +46,30 @@ ao_norm         = [[1.],
 # fxzz ->  f1 * sqrt(2/5)
 # fyzz ->  f1-* sqrt(2/5)
 # fxyz ->  f2-
-sph2cart        = [
-                   [ [[0],[1.]] ],                                     # conversion for s orbitals
-                   [ [[0],[1.]], [[1],[1.]], [[2],[1.]] ],             # conversion for p orbitals
-                   [ [[0,4],[-0.5/np.sqrt(3.), 0.5]],
-                     [[0,4],[-0.5/np.sqrt(3.),-0.5]],
-                     [[0],[1./np.sqrt(3.)]],
-                     [[3],[1.]],
-                     [[1],[1.]],          # conversion for d orbitals
-                     [[2],[1.]]],
-                   [ [[1,5],[-1/(2.*np.sqrt(10.)), 1./(2.*np.sqrt(6.))]],
-                     [[2,6],[-1/(2.*np.sqrt(10.)), 1./(2.*np.sqrt(6.))]], # conversion for f orbitals
-                     [[0], [1./np.sqrt(15.)]],
-                     [[2,6],[-1/(2.*np.sqrt(10.)),-np.sqrt(3.)/(2.*np.sqrt(2.))]],
-                     [[0,4],[-np.sqrt(3./5.)/2.  , 1./2.]],
-                     [[1,5],[-1/(2.*np.sqrt(10.)),-np.sqrt(3.)/(2.*np.sqrt(2.))]],
-                     [[0,4],[-np.sqrt(3./5.)/2.  ,-1./2.]],
-                     [[1],[np.sqrt(2./5.)]],
-                     [[2],[np.sqrt(2./5.)]],
-                     [[3],[1.]]]
-                  ]
+sph2cart = [
+    [[[0], [1.]]],                                          # conversion for s orbitals
+    [[[0], [1.]], [[1], [1.]], [[2], [1.]]],                # conversion for p orbitals
+    [[[0, 4], [-0.5/np.sqrt(3.),  0.5]],                    # conversion for d orbitals
+     [[0, 4], [-0.5/np.sqrt(3.), -0.5]],
+     [[0], [1./np.sqrt(3.)]],
+     [[3], [1.]],
+     [[1], [1.]],
+     [[2], [1.]]],
+    [[[1, 5], [-1/(2.*np.sqrt(10.)), 1./(2.*np.sqrt(6.))]], # conversion for f orbitals
+     [[2, 6], [-1/(2.*np.sqrt(10.)), 1./(2.*np.sqrt(6.))]],
+     [[0], [1./np.sqrt(15.)]],
+     [[2, 6], [-1/(2.*np.sqrt(10.)), -np.sqrt(3.)/(2.*np.sqrt(2.))]],
+     [[0, 4], [-np.sqrt(3./5.)/2., 1./2.]],
+     [[1, 5], [-1/(2.*np.sqrt(10.)), -np.sqrt(3.)/(2.*np.sqrt(2.))]],
+     [[0, 4], [-np.sqrt(3./5.)/2., -1./2.]],
+     [[1], [np.sqrt(2./5.)]],
+     [[2], [np.sqrt(2./5.)]],
+     [[3], [1.]]]
+            ]
 
 
 def parse(geom_file, geom_ordr, basis_file, mo_file):
-    """Documentation to come"""
+    """Parses a set of turbomole input files."""
     # read turbomole coord file
     gam_geom = read_geom(geom_file)
     if geom_ordr is not None:
@@ -84,7 +86,7 @@ def parse(geom_file, geom_ordr, basis_file, mo_file):
 
 
 def read_geom(geom_file):
-    """Reads a turbomole coord file and loads results into moinfo.Geom format"""
+    """Reads a turbomole coord file and loads results into moinfo.Geom."""
     # create geometry object to hold the data
     geom = moinfo.Geom()
 
@@ -107,8 +109,9 @@ def read_geom(geom_file):
 
     return geom
 
+
 def read_basis(basis_file, geom):
-    """Documentation to come"""
+    """Reads a turbomole basis file into moinfo.BasisSet."""
     # create basis set object
     basis = moinfo.BasisSet('unknown', geom)
 
@@ -182,13 +185,13 @@ def read_basis(basis_file, geom):
 
 
 def read_mos(mocoef_file, in_cart, basis):
-    """Documentation to come"""
+    """Reads a turbomole MO file into moinfo into moinfo.Orbitals.
 
-    # So: in the future, we should also allow for a mapping array that
-    # allows for taking linear combinations of elements in order to convert
-    # from a spherically adapted basis to cartesians. That will come later
-    # though...first the easy stuff.
-
+    So: in the future, we should also allow for a mapping array that
+    allows for taking linear combinations of elements in order to convert
+    from a spherically adapted basis to cartesians. That will come later
+    though... first the easy stuff.
+    """
     # slurp up the mocoef file
     with open(mocoef_file, 'r') as mos:
         mo_file = mos.readlines()
@@ -243,7 +246,8 @@ def read_mos(mocoef_file, in_cart, basis):
     elif n_aos == basis.n_bf_sph:
         in_cart = False
     else:
-        raise ValueError('Number of basis functions is not equal to: {:d}'.format(uniq[0]))
+        raise ValueError('Number of basis functions is not equal to: ' +
+                         '{:d}'.format(uniq[0]))
 
     # if in spherically adapted orbitals, first convert
     # to cartesians

--- a/turbomole.py
+++ b/turbomole.py
@@ -1,9 +1,7 @@
-# 
-# A set of routines to parse the output of a turbomole
-# calculation
-#
-#
-
+"""
+A set of routines to parse the output of a turbomole
+calculation.
+"""
 import sys
 import numpy as np
 import moinfo
@@ -26,14 +24,14 @@ ao_norm         = [[1.],
 
 
 # how to convert from spherical to cartesian basis functions (in turbomole ordering)
-# s -> s | px -> px | py -> py | pz -> pz 
+# s -> s | px -> px | py -> py | pz -> pz
 # d ordering: d0, d1, d1-, d2-, d2
 # dxx ->  0.5*( -d0/sqrt(3) + d2+ )
 # dyy ->  0.5*( -d0/sqrt(3) - d2+ )
 # dzz ->  d0 / sqrt(3)
-# dxy ->  d2- 
+# dxy ->  d2-
 # dxz ->  d1+
-# dyz ->  d1- 
+# dyz ->  d1-
 
 # f ordering: f0, f1, f1-, f2-, f2, f3, f3-
 # fxxx -> -f1+/sqrt(40) + f3+/sqrt(24)
@@ -49,94 +47,95 @@ ao_norm         = [[1.],
 sph2cart        = [
                    [ [[0],[1.]] ],                                     # conversion for s orbitals
                    [ [[0],[1.]], [[1],[1.]], [[2],[1.]] ],             # conversion for p orbitals
-                   [ [[0,4],[-0.5/np.sqrt(3.), 0.5]], 
-                     [[0,4],[-0.5/np.sqrt(3.),-0.5]], 
+                   [ [[0,4],[-0.5/np.sqrt(3.), 0.5]],
+                     [[0,4],[-0.5/np.sqrt(3.),-0.5]],
                      [[0],[1./np.sqrt(3.)]],
-                     [[3],[1.]], 
+                     [[3],[1.]],
                      [[1],[1.]],          # conversion for d orbitals
                      [[2],[1.]]],
-                   [ [[1,5],[-1/(2.*np.sqrt(10.)), 1./(2.*np.sqrt(6.))]], 
+                   [ [[1,5],[-1/(2.*np.sqrt(10.)), 1./(2.*np.sqrt(6.))]],
                      [[2,6],[-1/(2.*np.sqrt(10.)), 1./(2.*np.sqrt(6.))]], # conversion for f orbitals
                      [[0], [1./np.sqrt(15.)]],
                      [[2,6],[-1/(2.*np.sqrt(10.)),-np.sqrt(3.)/(2.*np.sqrt(2.))]],
-                     [[0,4],[-np.sqrt(3./5.)/2.  , 1./2.]], 
+                     [[0,4],[-np.sqrt(3./5.)/2.  , 1./2.]],
                      [[1,5],[-1/(2.*np.sqrt(10.)),-np.sqrt(3.)/(2.*np.sqrt(2.))]],
                      [[0,4],[-np.sqrt(3./5.)/2.  ,-1./2.]],
-                     [[1],[np.sqrt(2./5.)]], 
-                     [[2],[np.sqrt(2./5.)]], 
+                     [[1],[np.sqrt(2./5.)]],
+                     [[2],[np.sqrt(2./5.)]],
                      [[3],[1.]]]
-                  ] 
+                  ]
 
-def parse(geom_file, basis_file, mo_file):
+
+def parse(geom_file, geom_ordr, basis_file, mo_file):
     """Documentation to come"""
-
     # read turbomole coord file
-    gam_geom  = read_geom(geom_file)
-    
+    gam_geom = read_geom(geom_file)
+    if geom_ordr is not None:
+        gam_ordr = read_geom(geom_ordr)
+        gam_geom.reorder(gam_ordr)
+
     # parse basis file to get basis set information
-    [in_cart, gam_basis] = read_basis(basis_file, gam_geom)
+    in_cart, gam_basis = read_basis(basis_file, gam_geom)
 
     # parse mos file to pull out orbitals
-    gam_mos   = read_mos(mo_file, in_cart, gam_basis)
+    gam_mos = read_mos(mo_file, in_cart, gam_basis)
 
-    return [gam_basis, gam_mos]
+    return gam_basis, gam_mos
 
-#
+
 def read_geom(geom_file):
-    """reads a turbomole coord file and loads results into moinfo.geom format"""
-
+    """Reads a turbomole coord file and loads results into moinfo.Geom format"""
     # create geometry object to hold the data
-    geom = moinfo.geom()
+    geom = moinfo.Geom()
 
     # slurp up geometry file
-    with open(geom_file) as turbo_coord: 
+    with open(geom_file, 'r') as turbo_coord:
         gfile = turbo_coord.readlines()
 
     i = 0
-    while(gfile[i].split()[0] != "$coord"):
+    while(gfile[i].split()[0] != '$coord'):
         i+=1
-   
+
     atoms = []
     i+=1
     while('$' not in gfile[i]):
         gstr   = gfile[i].split() # format = coords, asym
         asym   = gstr[3].upper().rjust(2)
         coords = [float(gstr[i])*moinfo.au2ang for i in range(3)]
-        geom.add_atom(moinfo.atom(asym,coords))
-        i      += 1
+        geom.add_atom(moinfo.Atom(asym,coords))
+        i     += 1
 
     return geom
 
 def read_basis(basis_file, geom):
     """Documentation to come"""
-
     # create basis set object
-    basis = moinfo.basis_set('unknown',geom)
+    basis = moinfo.BasisSet('unknown', geom)
 
     # slurp up daltaoin file
-    with open(basis_file) as turbo_basis:
+    with open(basis_file, 'r') as turbo_basis:
         bfile = turbo_basis.readlines()
-   
+
     # default is to run in spherically adapted functions
     # can add for cartesians later (not sure how to check
     # that at the moment)
     in_cartesians = False
 
-    # look for start of basis section 
+    # look for start of basis section
     i = 0
-    while(bfile[i].split()[0] != "$basis"):
+    while(bfile[i].split()[0] != '$basis'):
         i += 1
 
     # iterate over the atom types
-    b_set     = ""
-    a_sym     = ""
+    b_set     = ''
+    a_sym     = ''
     sec_start = False
     i         += 1
     while True:
         line = bfile[i].split()
 
         # stepping on $end line breaks us out of parser
-        if line[0] == "$end":
+        if line[0] == '$end':
             break
 
         # ignore blank lines
@@ -145,41 +144,42 @@ def read_basis(basis_file, geom):
             continue
 
         # ignore comment lines
-        if line[0][0] == "#":
+        if line[0][0] == '#':
             i += 1
             continue
 
         # if first string is star, either
         # beginning or ending basis section
-        if line[0] == "*":
+        if line[0] == '*':
             sec_start = not sec_start
             i += 1
             continue
 
-        # if starting section, first line 
+        # if starting section, first line
         # is atom and basis set line
         if sec_start:
             a_sym = line[0]
             b_set = line[1]
-            a_lst = [ind for ind,sym in enumerate([geom.atoms[k].symbol 
-                       for k in range(geom.natoms())]) 
+            a_lst = [ind for ind,sym in enumerate([geom.atoms[k].symbol
+                       for k in range(geom.natoms())])
                        if sym == a_sym.upper().rjust(2)]
             i += 1
             continue
 
         # if we get this far, we're parsing the basis set!
-        [nprim, ang_sym] = line
+        nprim, ang_sym = line
         ang_mom          = moinfo.ang_mom_sym.index(ang_sym.upper())
-        bfunc            = moinfo.basis_function(ang_mom)
+        bfunc            = moinfo.BasisFunction(ang_mom)
         for j in range(int(nprim)):
             i += 1
             [exp, coef]  = bfile[i].split()
             bfunc.add_primitive(float(exp), float(coef))
         for atom in a_lst:
-            basis.add_function(atom, bfunc) 
+            basis.add_function(atom, bfunc)
         i += 1
 
-    return [in_cartesians, basis]
+    return in_cartesians, basis
+
 
 def read_mos(mocoef_file, in_cart, basis):
     """Documentation to come"""
@@ -187,10 +187,10 @@ def read_mos(mocoef_file, in_cart, basis):
     # So: in the future, we should also allow for a mapping array that
     # allows for taking linear combinations of elements in order to convert
     # from a spherically adapted basis to cartesians. That will come later
-    # though...first the easy stuff.    
+    # though...first the easy stuff.
 
     # slurp up the mocoef file
-    with open(mocoef_file) as mos:
+    with open(mocoef_file, 'r') as mos:
         mo_file = mos.readlines()
 
     i        = 0
@@ -199,11 +199,11 @@ def read_mos(mocoef_file, in_cart, basis):
     n_ao_all = []
     raw_orbs = []
     new_orb = False
-    while i<len(mo_file):
+    while i < len(mo_file):
         line = mo_file[i].split()
 
         # ignore the first line
-        if line[0] == "$scfmo" or line[0] == "$end":
+        if line[0] == '$scfmo' or line[0] == '$end':
             i += 1
             continue
 
@@ -211,8 +211,8 @@ def read_mos(mocoef_file, in_cart, basis):
         if line[0] == '#':
             i += 1
             continue
-    
-        # if line contains "eigenvalue", start new orbitals   
+
+        # if line contains "eigenvalue", start new orbitals
         if 'eigenvalue' in ' '.join(line).lower():
             raw_orbs.append([])
             n_ao_all.extend([0])
@@ -220,21 +220,21 @@ def read_mos(mocoef_file, in_cart, basis):
             new_orb = True
             i       += 1
             continue
- 
+
         # else, parse a line
-        mo_row = line[0].lower().replace('d','e') 
+        mo_row = line[0].lower().replace('d','e')
         n_cf = int(len(mo_row)/wid)
         for j in range(n_cf):
-            n_ao_all[-1] += 1  
+            n_ao_all[-1] += 1
             raw_orbs[-1].extend([float(mo_row[j*wid:(j+1)*wid])])
         i += 1
 
     # make sure all the mos are the same length
     uniq = list(set(n_ao_all))
     if len(uniq) != 1:
-        sys.exit('MOs have different numbers of AOs. Exiting...')
+        raise ValueError('MOs have different numbers of AOs. Exiting...')
     else:
-        n_aos = uniq[0]    
+        n_aos = uniq[0]
 
     # determine if we're running in cartesian or spherically adapted
     # atomic basis functions
@@ -243,7 +243,7 @@ def read_mos(mocoef_file, in_cart, basis):
     elif n_aos == basis.n_bf_sph:
         in_cart = False
     else:
-        sys.exit('Number of basis functions is not equal to: '+str(uniq[0]))
+        raise ValueError('Number of basis functions is not equal to: {:d}'.format(uniq[0]))
 
     # if in spherically adapted orbitals, first convert
     # to cartesians
@@ -255,16 +255,16 @@ def read_mos(mocoef_file, in_cart, basis):
         turb_orb_cart = turb_orb
         nao_cart      = n_aos
 
-    # copy orbitals into gam_orb 
-    gam_orb = moinfo.orbitals(nao_cart, n_mos)
+    # copy orbitals into gam_orb
+    gam_orb = moinfo.Orbitals(nao_cart, n_mos)
     gam_orb.mo_vectors = turb_orb_cart
 
     # construct mapping array from TURBOMOLE to GAMESS
-    [turb_gam_map, scale_turb, scale_gam] = basis.construct_map(ao_ordr, ao_norm)
+    turb_gam_map, scale_turb, scale_gam = basis.construct_map(ao_ordr, ao_norm)
 
     # remove the dalton normalization factors
     gam_orb.scale(scale_turb)
-  
+
     # re-sort orbitals to GAMESS ordering
     gam_orb.sort(turb_gam_map)
 
@@ -272,6 +272,3 @@ def read_mos(mocoef_file, in_cart, basis):
     gam_orb.scale(scale_gam)
 
     return gam_orb
-
-
-


### PR DESCRIPTION
Added support for specifying a file with a desired geometry order different from the original order, and support from reading occupation numbers from columbus inputs, if present (including SCF orbitals, which use a different number of columns from other columbus orbital files). Everything has been "pythonized".